### PR TITLE
Add optional arguments to `suggest` method.

### DIFF
--- a/datamuse/datamuse.py
+++ b/datamuse/datamuse.py
@@ -30,14 +30,9 @@ WORD_PARAMS = [
     'qe'
 ]
 
-SUGGEST_PARAMS = [
-    's',
-    'max',
-    'v'
-]
-
 
 class Datamuse(object):
+
     def __init__(self, max_results=100):
         self.api_root = 'https://api.datamuse.com'
         self._validate_max(max_results)
@@ -74,7 +69,28 @@ class Datamuse(object):
             kwargs.update({'max': self.max})
         return self._get_resource('words', **kwargs)
 
-    def suggest(self, **kwargs):
-        """https://www.datamuse.com/api/"""
-        self._validate_args(kwargs, SUGGEST_PARAMS)
-        return self._get_resource('sug', **kwargs)
+    def suggest(self, s, max_results=None, vocabulary=None):
+        """
+        This resource is useful as a backend for “autocomplete” widgets
+        on websites and apps when the vocabulary of possible search terms
+        is very large.
+
+        It provides word suggestions given a partially-entered query
+        using a combination of the operations.
+
+        The suggestions perform live spelling correction and intelligently
+        fall back to choices that are phonetically or semantically similar
+        when an exact prefix match can't be found.
+
+        :param s: Prefix hint string; typically, the characters that
+            the user has entered so far into a search box.
+        :param max_results: Maximum number of results to return, not to exceed 1000.
+        :param vocabulary: The language vocabulary to use. Currently, `en` and `es` are supported.
+        :return: A list of suggested words to the given string s.
+        """
+        payload = {'s': s}
+        if max_results is not None:
+            payload['max'] = max_results
+        if vocabulary is not None:
+            payload['v'] = vocabulary
+        return self._get_resource('sug', **payload)

--- a/tests/datamuse/fixtures/por.json
+++ b/tests/datamuse/fixtures/por.json
@@ -1,0 +1,14 @@
+[
+  {
+    "word": "por",
+    "score": 5551294
+  },
+  {
+    "word": "porque",
+    "score": 484246
+  },
+  {
+    "word": "porcentaje",
+    "score": 37097
+  }
+]

--- a/tests/datamuse/test_api.py
+++ b/tests/datamuse/test_api.py
@@ -39,6 +39,15 @@ class DatamuseTestCase(unittest.TestCase):
                       urljoin(_api_url, f'?ml=ringing+in+the+ears'),
                       json=response_json, status=200)
 
+
+        _fp = pkg_resources.resource_filename(__name__, 'fixtures/por.json')
+        with open(_fp) as response_json:
+            response_json = json.load(response_json)
+        responses.add(responses.GET,
+                      urljoin(_api_url, f'?s=por&max=3'),
+                      json=response_json, status=200)
+
+
     def test_sounds_like(self):
         args = {'sl': 'orange', 'max': self.max}
         data = self.api.words(**args)
@@ -75,6 +84,11 @@ class DatamuseTestCase(unittest.TestCase):
             self.api.set_max_default(0)
             self.api.set_max_default(1001)
 
+    def test_suggest(self):
+        response = self.api.suggest(s='por', max_results=3, vocabulary='es')
+        assert len(response) == 3
+        assert isinstance(response, list)
+        assert response[1]['word'] == 'porque'
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Instead of having a list of possible keyword arguments to suggest, be more prescriptive and have them as named arguments in the function signature.

Changelog:

- Remove `SUGGEST_PARAMS` in favor of using named arguments in function signature.
- Add a happy path test for the suggestion endpoint.
- Add docstring documentation for the suggestion method.
- The implementation does not change anything in the interface ⭐️ 