### PR TITLE
fix(test): wrap multi-word query in single quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# JetBrains
-.idea/*
+# Editors
+.idea/
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -63,3 +64,4 @@ target/
 
 # VirtualEnv
 datamuse-env/
+.venv/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ install this library with `pip3 install python-datamuse`.
 - **(1.3.1):** Update README example
 - **(1.3.1):** Remove WORD_PARAMS
 - **(1.3.1):** Document `words` method
+- **(1.3.2) (2022-04-04):** Fix test_set_max bug 
 
 ### Version 1.2.* (2018-10-23)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="python-datamuse",
-    version="1.3.1",
+    version="1.3.2",
     keywords="datamuse, linguistics, language, wrapper",
     packages=["datamuse"],
     url="https://github.com/gmarmstrong/python-datamuse",

--- a/tests/datamuse/test_api.py
+++ b/tests/datamuse/test_api.py
@@ -70,7 +70,7 @@ class DatamuseTestCase(unittest.TestCase):
         self.assertTrue(self.api.max, 100)
         self.api.set_max_default(10)
         self.assertEqual(self.api.max, 10)
-        data = self.api.words(ml='ringing in the ears')
+        data = self.api.words(ml="'ringing in the ears'")
         self.assertEqual(len(data), 10)
 
     def test_set_max_error(self):


### PR DESCRIPTION
Fixes the `test_set_max` test case, which had been failing.